### PR TITLE
Update styles.js

### DIFF
--- a/src/pages/User/styles.js
+++ b/src/pages/User/styles.js
@@ -38,7 +38,7 @@ export const Bio = styled.Text`
 
 export const Loading = styled.ActivityIndicator.attrs({
   color: '#7159c1',
-  size: 50,
+  size: 'large',
 })`
   flex: 1;
   justify-content: center;


### PR DESCRIPTION
Passando um número pra propriedade size do ActivityIndicator só funciona no android de acordo com a documentação, no iOS o indicador ainda vai continuar pequeno, setando como 'large' ele fica grande nos dois.

Se por acaso ainda achar que no android esta pequeno, pode-se importar o Platform do react-native:

`import { Platform } from 'react-native;`

e na propriedade size do ActivityIndicator colocar:

`size: Platform.OS === 'ios' ? 'large' : 50,`